### PR TITLE
Define scripts section in package.json and use local instalation of gulp.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ node_js:
 install:
   - "npm install"
 script:
-  - "./node_modules/gulp/bin/gulp.js build"
-  - "./node_modules/gulp/bin/gulp.js lint"
-  - "./node_modules/gulp/bin/gulp.js test"
+  - "npm run build"
+  - "npm run lint"
+  - "npm run test"
 after_success:
   - "./node_modules/codecov/bin/codecov"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ script:
   - "npm run lint"
   - "npm run test"
 after_success:
-  - "./node_modules/codecov/bin/codecov"
+  - "npm run codecov"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "serve": "./node_modules/.bin/gulp serve",
     "build": "./node_modules/.bin/gulp build",
+    "lint": "./node_modules/.bin/gulp lint",
     "test": "./node_modules/.bin/gulp test"
   },
   "author": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "serve": "./node_modules/.bin/gulp serve",
     "build": "./node_modules/.bin/gulp build",
     "lint": "./node_modules/.bin/gulp lint",
-    "test": "./node_modules/.bin/gulp test"
+    "test": "./node_modules/.bin/gulp test",
+    "codecov": "./node_modules/.bin/codecov"
   },
   "author": {
     "name": "Komitywa",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "homepage": "http://plantingjs.org",
   "bugs": "https://github.com/komitywa/plantingjs/issues",
   "license": "MIT",
+  "scripts": {
+    "serve": "./node_modules/.bin/gulp serve",
+    "build": "./node_modules/.bin/gulp build",
+    "test": "./node_modules/.bin/gulp test"
+  },
   "author": {
     "name": "Komitywa",
     "email": "komitywapoznan@gmail.com",


### PR DESCRIPTION
Thanks to this few lines we can easily build engine without installing gulp globally or typing whole node_modules path. After `npm install` just type one of the options:

``` bash
npm run serve
npm run build
npm run test
```

@magul 
@rudymichal 
