### PR TITLE
Modal Component

### DIFF
--- a/src/js/modules/components/modal.hbs
+++ b/src/js/modules/components/modal.hbs
@@ -1,5 +1,5 @@
+<div class="plantingjs-modal-background"></div>
 <div class="plantingjs-modal-inner">
-  <div class="plantingjs-modal-content">
-    
-  </div>
+  <button class="plantingjs-modal-close-btn">&#x2715;</button>
+  <div class="plantingjs-modal-content"></div>
 </div>

--- a/src/js/modules/components/modal.hbs
+++ b/src/js/modules/components/modal.hbs
@@ -1,0 +1,5 @@
+<div class="plantingjs-modal-inner">
+  <div class="plantingjs-modal-content">
+    
+  </div>
+</div>

--- a/src/js/modules/components/modal.js
+++ b/src/js/modules/components/modal.js
@@ -1,0 +1,7 @@
+import { View } from 'backbone';
+
+export default View.extend({
+  initialize() {
+    console.log(this);
+  }
+});

--- a/src/js/modules/components/modal.js
+++ b/src/js/modules/components/modal.js
@@ -2,15 +2,40 @@ import { View } from 'backbone';
 import modalTemplate from './modal.hbs';
 
 const HIDDEN_CLASS = 'hidden';
+const CONTENT_CLASS = 'plantingjs-modal-content';
 
 export default View.extend({
+  events: {
+    'click .plantingjs-modal-background': 'hide',
+    'click .plantingjs-modal-close-btn': 'hide',
+  },
+
+  constructor({ childView, ...opts }) {
+    this.childView = childView;
+    View.call(this, opts);
+  },
+
   initialize() {
     this.render();
+    this.$el
+      .toggleClass(HIDDEN_CLASS, false)
+      .find(`.${CONTENT_CLASS}`)
+        .html(this.childView.$el);
+  },
+
+  hide() {
+    this.$el
+      .toggleClass(HIDDEN_CLASS, true);
+  },
+
+  show() {
     this.$el
       .toggleClass(HIDDEN_CLASS, false);
   },
 
   _removeElement() {
+    this.childView
+      .remove();
     this.$el
       .toggleClass(HIDDEN_CLASS, true)
       .children()

--- a/src/js/modules/components/modal.js
+++ b/src/js/modules/components/modal.js
@@ -1,7 +1,24 @@
 import { View } from 'backbone';
+import modalTemplate from './modal.hbs';
+
+const HIDDEN_CLASS = 'hidden';
 
 export default View.extend({
   initialize() {
-    console.log(this);
-  }
+    this.render();
+    this.$el
+      .toggleClass(HIDDEN_CLASS, false);
+  },
+
+  _removeElement() {
+    this.$el
+      .toggleClass(HIDDEN_CLASS, true)
+      .children()
+      .remove();
+  },
+
+  render() {
+    this.$el
+      .html(modalTemplate());
+  },
 });

--- a/src/js/modules/main/main.hbs
+++ b/src/js/modules/main/main.hbs
@@ -7,4 +7,5 @@
     <div class="plantingjs-toolbox"></div>
     <div class="plantingjs-overlay ui-droppable"></div>
     <div class="plantingjs-google"></div>
+    <div class="plantingjs-modal"></div>
 </div>

--- a/src/js/modules/main/main.hbs
+++ b/src/js/modules/main/main.hbs
@@ -7,5 +7,5 @@
     <div class="plantingjs-toolbox"></div>
     <div class="plantingjs-overlay ui-droppable"></div>
     <div class="plantingjs-google"></div>
-    <div class="plantingjs-modal"></div>
+    <div class="plantingjs-modal hidden"></div>
 </div>

--- a/src/js/modules/main/main.js
+++ b/src/js/modules/main/main.js
@@ -19,6 +19,7 @@ const SELECT_PANO_INIT_VALUES = {
   label: 'wybierz',
   visible: false,
 };
+const MODAL_SELECTOR = '.plantingjs-modal';
 
 export default View.extend({
   toolbox: null,
@@ -87,5 +88,9 @@ export default View.extend({
      */
     event.preventDefault();
     this.session().save();
+  },
+
+  getModal() {
+    return this.$el.find(MODAL_SELECTOR);
   },
 });

--- a/src/js/modules/main/main.js
+++ b/src/js/modules/main/main.js
@@ -19,7 +19,7 @@ const SELECT_PANO_INIT_VALUES = {
   label: 'wybierz',
   visible: false,
 };
-const MODAL_SELECTOR = '.plantingjs-modal';
+const MODAL_CLASS = 'plantingjs-modal';
 
 export default View.extend({
   toolbox: null,
@@ -91,6 +91,6 @@ export default View.extend({
   },
 
   getModal() {
-    return this.$el.find(MODAL_SELECTOR);
+    return this.$el.find(`.${MODAL_CLASS}`);
   },
 });

--- a/src/js/planting.js
+++ b/src/js/planting.js
@@ -19,6 +19,7 @@ export default class extends EventEmitter {
 
     super(options);
     this._state = null;
+    this.visibleModal = null;
     this.options = options;
     this.data = {
       session: new SessionDataModel(null, {
@@ -142,14 +143,17 @@ export default class extends EventEmitter {
       });
   }
 
-  modal(BackboneView) {
-    const modalInstance = new ModalView({
-      childView: new BackboneView({ app: this }),
+  modal(ChildView) {
+    if (this.visibleModal) {
+      this.visibleModal.remove();
+      this.visibleModal = null;
+    }
+
+    this.visibleModal = new ModalView({
+      childView: new ChildView({ app: this }),
       el: this.main.getModal(),
     });
 
-    return modalInstance;
+    return this.visibleModal;
   }
 }
-
-window.TestView = View.extend({});

--- a/src/js/planting.js
+++ b/src/js/planting.js
@@ -10,7 +10,7 @@ import PlantOverlayView from './modules/plant/overlay';
 import Sidebar from './modules/toolbox/sidebar';
 import MapView from './modules/map/map';
 import LayersManagerView from './modules/layers-manager/menu-view';
-
+import ModalView from './modules/components/modal';
 
 export default class extends EventEmitter {
   constructor(options) {
@@ -139,5 +139,14 @@ export default class extends EventEmitter {
             this.trigger(Const.Event.START_PLANTING);
           });
       });
+  }
+
+  modal(BackboneView) {
+    const modalInstance = new ModalView({
+      childView: new BackboneView({ app: this }) });
+    const $modalHolder = this.main.$.find('plantingjs-modal');
+
+    console.log($modalHolder);
+    return modalInstance;
   }
 }

--- a/src/js/planting.js
+++ b/src/js/planting.js
@@ -1,5 +1,4 @@
 import { Deferred as deferredObject } from 'jquery';
-import { View } from 'backbone';
 import 'jquery-ui';
 import lodash from 'lodash';
 import EventEmitter from './event-emitter';

--- a/src/js/planting.js
+++ b/src/js/planting.js
@@ -1,4 +1,5 @@
 import { Deferred as deferredObject } from 'jquery';
+import { View } from 'backbone';
 import 'jquery-ui';
 import lodash from 'lodash';
 import EventEmitter from './event-emitter';
@@ -143,10 +144,12 @@ export default class extends EventEmitter {
 
   modal(BackboneView) {
     const modalInstance = new ModalView({
-      childView: new BackboneView({ app: this }) });
-    const $modalHolder = this.main.$.find('plantingjs-modal');
+      childView: new BackboneView({ app: this }),
+      el: this.main.getModal(),
+    });
 
-    console.log($modalHolder);
     return modalInstance;
   }
 }
+
+window.TestView = View.extend({});

--- a/src/styles/_modal.scss
+++ b/src/styles/_modal.scss
@@ -1,4 +1,9 @@
+$close-btn-offset: 12px;
+
 .plantingjs-modal {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   position: absolute;
   top: 0;
   left: 0;
@@ -8,17 +13,48 @@
 
   &.hidden {
     display: none;
-    
-    .plantingjs-modal-inner {
-      opacity: 0;
+  }
+
+  &-background {
+    background: rgba(#4A4A4A, 0.8);
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    left: 0;
+    top: 0;
+    z-index: -1;
+
+    &:hover {
+      cursor: pointer;
     }
   }
 
   &-inner {
-    background: #4A4A4A;
-    opacity: .7;
-    width: 100%;
-    height: 100%;
-    transition: opacity $default-transition;
+    position: relative;
+    max-width: 80%;
+  }
+
+  &-content {
+    background: #fff;
+    padding: 20px;
+  }
+
+  &-close-btn {
+    background: #000;
+    border: none;
+    border-radius: 10px;
+    color: #fff;
+    position: absolute;
+    padding: 4px 6px;
+    right: $close-btn-offset / -1;
+    top: $close-btn-offset / -1;
+
+    &:hover {
+      cursor: pointer;
+    }
+
+    &:focus {
+      outline: none;
+    }
   }
 }

--- a/src/styles/_modal.scss
+++ b/src/styles/_modal.scss
@@ -1,0 +1,24 @@
+.plantingjs-modal {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 1000;
+
+  &.hidden {
+    display: none;
+    
+    .plantingjs-modal-inner {
+      opacity: 0;
+    }
+  }
+
+  &-inner {
+    background: #4A4A4A;
+    opacity: .7;
+    width: 100%;
+    height: 100%;
+    transition: opacity $default-transition;
+  }
+}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -4,3 +4,4 @@
 @import 'planting';
 @import 'toolbox';
 @import 'component';
+@import 'modal';


### PR DESCRIPTION
Engine now exposes `modal` method, which accepts Backbone.View class.

``` javascript
/**
 * Create some simple Backbone.View class
 */
const MyModal = Backbone.View.extend({
  initialize() {
    this.$el.html(`
      <h1>My awesome title</h1>
      <p>My irritating message</p>
    `);
  }
});

/**
 * Show MyModal
 */
const modal = PlantingInstance.modal(MyModal);

/**
 * `modal` returns instance of `components/modal`.
 * We can easily access instance of MyModal and change stuff on fly.
 */
modal.childView.$el.html(`
  <h1>My new irritating title</h1>
  <p>My awesome message</p>
`);
```

@magul 
@rudymichal 
