### PR TITLE
position undefined when starting planting

### DIFF
--- a/src/js/modules/map/map.js
+++ b/src/js/modules/map/map.js
@@ -67,7 +67,7 @@ export default View.extend({
 
     return this.initializeMaps()
       .then((google) => {
-        this.map = new google.maps.StreetViewPanorama(element, options);
+        this.panorama = new google.maps.StreetViewPanorama(element, options);
       });
   },
 


### PR DESCRIPTION
When initializing viewer, we need to store Google Maps object in panorama
attribute, instead of map.

Resolve #201

@cmwd @Thorleon @gruber86 please review
